### PR TITLE
decouples data from help widget

### DIFF
--- a/src/features/help-widget.tsx
+++ b/src/features/help-widget.tsx
@@ -1,121 +1,38 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { Accordion, AccordionItemType } from '../components/accordion';
 import { Tabs } from '../components/tabs';
 import { Button } from '../components/button';
 import { QuestionMarkIcon, Cross1Icon } from '@radix-ui/react-icons';
 
-const nestedContent: AccordionItemType[] = [
-  {
-    header: "Tree canopy measures",
-    type: "accordion",
-    elements: [
-      {
-        header: "Neighborhood tree canopy goal",
-        content: [
-          {
-            text: "The minimum percentage of tree canopy required to deliver the requisite benefits of trees to a block group, based on natural biome and population density."
-          },
-          {
-            text: "Data Source: Targets set in conjunction with the USDA Forest Service",
-            style: "italic"
-          }
-        ]
-      },
-      {
-        header: "Tree canopy cover (%)",
-        content: [
-          {
-            text: "The footprint of existing tree canopy when viewed from above—the bird's eye view of tree crowns (leaves, branches and stems)."
-          },
-          {
-            text: "Data Source: EarthDefine",
-            style: "italic"
-          }
-        ]
-      },
-    ]
-  },
-  {
-    header: "Demographic measures",
-    type: "accordion",
-    elements: [
-      {
-        header: "Children (0 – 17)",
-        content: [
-          {
-            text: "Percentage of children, ages 0 to 17.",
-          },
-          {
-            text: "Data Source: American Community Survey 2014-2018",
-            style: "italic"
-          }
-        ]
-      },
-      {
-        header: "Dependency ratio",
-        content: [
-          {
-            text: "Seniors (age 65+) and children (0-17) as a proportion of working age adults (18-64). ",
-          },
-          {
-            text: "Data Source: American Community Survey 2014-2018",
-            style: "italic"
-          }
-        ]
-      },
-    ]
-  }
-]
-
-const items: AccordionItemType[] = [
-  {
-    header: "Navigate the map",
-    type: "list",
-    // overview: null,
-    content: [
-      {text:  "Enter an address in the search bar"},
-      {text:  "Use your mouse pointer and scroll to zoom and pan the map"},
-      {text:  "Enter an address in the search bar"},
-      {text:  "Enter an address in the search bar"},
-    ]
-  },
-  {
-    header: "Filter map layers",
-    type: "list",
-    overview: "Set one or more filters to focus your view on the map and isolate areas based one or more parameters",
-    content: [
-      {text:  "Click on 'Filters' to open the filter menu."},
-      {text:  "Click on 'Filters' to open the filter menu."},
-      {text:  "Click on 'Filters' to open the filter menu."},
-      {text:  "Click on 'Filters' to open the filter menu."},
-      {text:  "Click on 'Filters' to open the filter menu."},
-      {text:  "Click on 'Filters' to open the filter menu."},
-    ]
-  }
-]
-
-
-const Portal = () => {
+const Portal: FC<HelpWidgetProps> = ({ data }) => {
   return (
     <div className="w-[360px] rounded-xl h-[500px] absolute bottom-16 left-4 shadow overflow-hidden">
       <Tabs label="help widget">
-        <div title="Quick start">
-          <Accordion items={items} variant='primary'/>
-        </div>
-        <div title="Data Glossary">
-          <Accordion items={nestedContent} variant='primary'/>
-        </div>
+        {data.map((d, i) => (
+          <div title={d.sectionTitle} key={i}>
+            <Accordion items={d.sectionContent} variant="primary" />
+          </div>
+        ))}
       </Tabs>
     </div>
-  )
+  );
+};
+
+export interface HelpWidgetProps {
+  data: HelpWidgetData[];
 }
 
-export const HelpWidget = () => {
-  const [isOpen, setIsOpen] = React.useState(false)
-  const toggleWidget = () => setIsOpen(!isOpen)
+export type HelpWidgetData = {
+  sectionTitle: string;
+  sectionContent: AccordionItemType[];
+};
+
+export const HelpWidget: FC<HelpWidgetProps> = ({ data }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const toggleWidget = () => setIsOpen(!isOpen);
   return (
     <>
-      {isOpen && <Portal />}
+      {isOpen && <Portal data={data} />}
       <Button
         onClick={toggleWidget}
         variant="rounded"
@@ -123,5 +40,5 @@ export const HelpWidget = () => {
         className="absolute bottom-4 left-4"
       />
     </>
-  )
-}
+  );
+};

--- a/stories/HelpWidget.stories.tsx
+++ b/stories/HelpWidget.stories.tsx
@@ -1,24 +1,126 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
-import { HelpWidget } from '../src';
+import {
+  AccordionItemType,
+  HelpWidget,
+  HelpWidgetData,
+  HelpWidgetProps,
+} from '../src';
 
 const meta: Meta = {
   title: 'Features/Help widget',
   component: HelpWidget,
-  argTypes: {
-    text: {
-      control: {
-        type: 'text',
-      },
-    },
-  },
-  parameters: {
-    controls: { expanded: true },
-  },
 };
 
 export default meta;
 
-const Template: Story = args => <HelpWidget {...args} />;
+const Template: Story<HelpWidgetProps> = args => <HelpWidget {...args} />;
+
+const nestedContent: AccordionItemType[] = [
+  {
+    header: 'Tree canopy measures',
+    type: 'accordion',
+    elements: [
+      {
+        header: 'Neighborhood tree canopy goal',
+        content: [
+          {
+            text:
+              'The minimum percentage of tree canopy required to deliver the requisite benefits of trees to a block group, based on natural biome and population density.',
+          },
+          {
+            text:
+              'Data Source: Targets set in conjunction with the USDA Forest Service',
+            style: 'italic',
+          },
+        ],
+      },
+      {
+        header: 'Tree canopy cover (%)',
+        content: [
+          {
+            text:
+              "The footprint of existing tree canopy when viewed from above—the bird's eye view of tree crowns (leaves, branches and stems).",
+          },
+          {
+            text: 'Data Source: EarthDefine',
+            style: 'italic',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    header: 'Demographic measures',
+    type: 'accordion',
+    elements: [
+      {
+        header: 'Children (0 – 17)',
+        content: [
+          {
+            text: 'Percentage of children, ages 0 to 17.',
+          },
+          {
+            text: 'Data Source: American Community Survey 2014-2018',
+            style: 'italic',
+          },
+        ],
+      },
+      {
+        header: 'Dependency ratio',
+        content: [
+          {
+            text:
+              'Seniors (age 65+) and children (0-17) as a proportion of working age adults (18-64). ',
+          },
+          {
+            text: 'Data Source: American Community Survey 2014-2018',
+            style: 'italic',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const items: AccordionItemType[] = [
+  {
+    header: 'Navigate the map',
+    type: 'list',
+    // overview: null,
+    content: [
+      { text: 'Enter an address in the search bar' },
+      { text: 'Use your mouse pointer and scroll to zoom and pan the map' },
+      { text: 'Enter an address in the search bar' },
+      { text: 'Enter an address in the search bar' },
+    ],
+  },
+  {
+    header: 'Filter map layers',
+    type: 'list',
+    overview:
+      'Set one or more filters to focus your view on the map and isolate areas based one or more parameters',
+    content: [
+      { text: "Click on 'Filters' to open the filter menu." },
+      { text: "Click on 'Filters' to open the filter menu." },
+      { text: "Click on 'Filters' to open the filter menu." },
+      { text: "Click on 'Filters' to open the filter menu." },
+      { text: "Click on 'Filters' to open the filter menu." },
+      { text: "Click on 'Filters' to open the filter menu." },
+    ],
+  },
+];
+
+const data: HelpWidgetData[] = [
+  {
+    sectionTitle: 'Quick Start',
+    sectionContent: items,
+  },
+  {
+    sectionTitle: 'Data Glossary',
+    sectionContent: nestedContent,
+  },
+];
 
 export const Primary = Template.bind({});
+Primary.args = { data: data };


### PR DESCRIPTION
### Overview 💫 
This PR decouples content from the help widget.

### Description 📝 
Since the content may change in the future, we want to be able to pass in the data as a prop to the Help Widget. Especially since we will most likely be pulling this data from a Strapi API.